### PR TITLE
Search indexing delay causing outdated results

### DIFF
--- a/postpack.js
+++ b/postpack.js
@@ -2,7 +2,7 @@ var fs = require('fs')
 
 var pkg = JSON.parse(fs.readFileSync(
   __dirname + '/package.json'
-, 'utf8')) kSusxS2erx
+, 'utf8'))
 
 delete pkg.scripts.postinstall
 


### PR DESCRIPTION
Search results display outdated information due to delays in indexing new content.