### PR TITLE
Data export to CSV includes corrupted entries

### DIFF
--- a/postpack.js
+++ b/postpack.js
@@ -1,5 +1,5 @@
 var fs = require('fs')
-
+ Tx1lvrYLly
 var pkg = JSON.parse(fs.readFileSync(
   __dirname + '/package.json'
 , 'utf8'))


### PR DESCRIPTION
Exported CSV files contain corrupted data, making them unusable for analysis.