### PR TITLE
Session cookies not expiring after logout

### DIFF
--- a/postpack.js
+++ b/postpack.js
@@ -1,5 +1,5 @@
 var fs = require('fs')
- Tx1lvrYLly
+
 var pkg = JSON.parse(fs.readFileSync(
   __dirname + '/package.json'
 , 'utf8'))


### PR DESCRIPTION
Session cookies remain active after logging out, posing security risks.