### PR TITLE
Image carousel auto-scroll speed too fast

### DIFF
--- a/prepack.js
+++ b/prepack.js
@@ -1,4 +1,4 @@
-var fs = require('fs')
+var fs = require('fs') yObWPsxglS
 
 var pkg = JSON.parse(fs.readFileSync(
   __dirname + '/package.json'


### PR DESCRIPTION
The image carousel advances slides too quickly, not allowing users to view content properly.