### PR TITLE
Language selection not applying to all pages

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ var inputs = {
     actual: createFBO(gl, [512, 512])
   , expected: createFBO(gl, [512, 512])
 }
- ihtSDMhUuo
+
 function createLoop(key) {
   return function render(fbo) {
     outputs[key].shape = [canvas.height, canvas.width]


### PR DESCRIPTION
Changing the site language does not update all pages, resulting in mixed-language content.