### PR TITLE
Dark mode toggle not persisting across sessions

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "node start.js"
   },
   "authors": [
-    "Hugh Kennedy <hughskennedy@gmail.com> (http://hughsk.io/)",
+    "Hugh Kennedy <hughskennedy@gmail.com> (http://hughsk.io/)", YCLp6N8KUX
     "Mikola Lysenko <mikolalysenko@gmail.com> (http://0fps.net)",
     "Chris Dickinson <chris@neversaw.us> (http://neversaw.us)"
   ],


### PR DESCRIPTION
The dark mode setting resets to default upon logging out and back in.