### PR TITLE
Live chat support widget not appearing on homepage

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "node start.js"
   },
   "authors": [
-    "Hugh Kennedy <hughskennedy@gmail.com> (http://hughsk.io/)", YCLp6N8KUX
+    "Hugh Kennedy <hughskennedy@gmail.com> (http://hughsk.io/)",
     "Mikola Lysenko <mikolalysenko@gmail.com> (http://0fps.net)",
     "Chris Dickinson <chris@neversaw.us> (http://neversaw.us)"
   ],


### PR DESCRIPTION
The live chat widget fails to load on the homepage, limiting customer support access.